### PR TITLE
chore: add quality of life and type hint improvement to `Animals` class within `rag_to_riches/corpus` && ensured passing test cases.

### DIFF
--- a/src/rag_to_riches/corpus/animals.py
+++ b/src/rag_to_riches/corpus/animals.py
@@ -9,22 +9,38 @@
 
 import json
 from pathlib import Path
-from typing import List, Optional, Dict, Any, Union
-from uuid import uuid4
+from typing import (
+    List,
+    Optional,
+    Any,
+    TypeAlias,
+    Literal,
+    TypedDict,
+    overload,
+)
 from icontract import require, ensure
 from pydantic import BaseModel, Field, ConfigDict, field_validator
 from qdrant_client import models
 from loguru import logger
 
-# Import instructor and OpenAI for LLM integration
+# import instructor for LLM integration
+# NOTE: quality-of-life change, but probably not needed
 import instructor
-from openai import OpenAI
+# NOTE: literal type, contains model names that `instructor` can auto-infer
+# provider from
+from instructor.models import KnownModelName
+# NOTE: this is used to get rid of the overload type error that occurs when calling
+# client.create or client.chat.completions.create, allowing proper type on response
+from openai.types.chat import ChatCompletionMessageParam, ChatCompletionUserMessageParam
 
 from rag_to_riches.vectordb.embedded_vectordb import EmbeddedVectorDB
 from rag_to_riches.vectordb.embedder import SimpleTextEmbedder
 from rag_to_riches.search.semantic_search import SemanticSearch
 from rag_to_riches.exceptions import InvalidPointsError
 from rag_to_riches.corpus.data_models import AnimalQuote, AnimalWisdom
+
+
+ResponseType: TypeAlias = Literal["structured", "simple"]
 
 
 #============================================================================================
@@ -82,6 +98,41 @@ class Animals:
         wisdom: Loaded collection of animal quotes (None until loaded)
         semantic_search: Underlying search engine for similarity queries
     """
+
+    # ----------------------------------------------------------------------------------------
+    #  Typed Response Objects
+    # ----------------------------------------------------------------------------------------
+    class CollectionStats(TypedDict):
+        collection_name: str
+        collection_exists: bool
+        point_count: int
+        loaded_quotes: int
+        categories: List[str]
+        authors: List[str]
+
+    class RagQueryInfo(TypedDict):
+        user_query: str
+        limit: int
+        score_threshold: Optional[float]
+        author_filter: Optional[str]
+        category_filter: Optional[str]
+        model: str
+        response_type: ResponseType
+        results_count: int
+
+    class RagResultStructured(TypedDict):
+        llm_response: "Animals.AnimalWisdomResponse"
+        search_results: List[models.ScoredPoint]
+        rag_context: str
+        query_info: "Animals.RagQueryInfo"
+
+    class RagResultSimple(TypedDict):
+        llm_response: str
+        search_results: List[models.ScoredPoint]
+        rag_context: str
+        query_info: "Animals.RagQueryInfo"
+
+    RagResult: TypeAlias = RagResultStructured | RagResultSimple
     
     # ----------------------------------------------------------------------------------------
     #  Constructor
@@ -559,7 +610,7 @@ class Animals:
     # ----------------------------------------------------------------------------------------
     #  Get Collection Stats
     # ----------------------------------------------------------------------------------------
-    def get_collection_stats(self) -> Dict[str, Any]:
+    def get_collection_stats(self) -> CollectionStats:
         """Get comprehensive statistics and insights about your quote collection.
         
         Provides a detailed overview of your collection's size, content diversity,
@@ -599,7 +650,7 @@ class Animals:
             - Monitor collection growth over time
             - Validate data integrity after operations
         """
-        stats = {
+        stats: Animals.CollectionStats = {
             "collection_name": self.collection_name,
             "collection_exists": self.semantic_search.vector_db.collection_exists(self.collection_name),
             "point_count": 0,
@@ -1026,7 +1077,7 @@ Please answer the user's question using the provided quotes and following the gu
                 score_threshold: Optional[float] = None,
                 author: Optional[str] = None,
                 category: Optional[str] = None,
-                model: str = "gpt-4o") -> AnimalWisdomResponse:
+                model: str | KnownModelName = "openai/gpt-4o") -> AnimalWisdomResponse:
         """Ask AI thoughtful questions about animals and get structured, insightful answers.
         
         This method combines the power of semantic search with advanced AI reasoning
@@ -1044,8 +1095,9 @@ Please answer the user's question using the provided quotes and following the gu
                 Higher values ensure more relevant context for better answers.
             author: Focus the answer on quotes from this specific author only.
             category: Limit context to quotes from this category only.
-            model: OpenAI model to use. "gpt-4o" (default) provides the most
-                thoughtful responses, "gpt-3.5-turbo" is faster and cheaper.
+            model: Language model to use for response generation. This supports all models
+                that are supported by instructor. (See `instructor.models.KnownModelName` for
+                supported models and providers).
         
         Returns:
             AnimalWisdomResponse containing:
@@ -1099,15 +1151,33 @@ Please answer the user's question using the provided quotes and following the gu
             )
             
             # Create instructor-patched client
-            client = instructor.from_openai(OpenAI())
+            try:
+                client = instructor.from_provider(
+                    model = model,
+                    # `instructor.from_provider` defaults to an async client
+                    async_client = False
+                )
+            # instructor's from_provider raises ImportError if provider sdk not installed
+            # (eg. anthropic)
+            # im only raising this here because im not sure if it would be appropriate to raise
+            # during invocation time
+            except (ImportError, ValueError) as e:
+                # not sure if i should raise custom error here, using valueerror for now
+                raise ValueError(f"Failed to auto-infer instructor client for model: {model}")
+
+            # build messages
+            # this is used to avoid instructor's overload type error
+            message : ChatCompletionMessageParam = ChatCompletionUserMessageParam(
+                content = rag_context,
+                role = "user"
+            )
+            messages : List[ChatCompletionMessageParam] = [message]
             
             # Get structured response from LLM
             response = client.chat.completions.create(
-                model=model,
                 response_model=self.AnimalWisdomResponse,
-                messages=[
-                    {"role": "user", "content": rag_context}
-                ]
+                messages=messages,
+                max_retries=3,
             )
             
             logger.info(f"LLM response generated for query: '{user_query[:50]}...'")
@@ -1123,13 +1193,15 @@ Please answer the user's question using the provided quotes and following the gu
     @require(lambda user_query: isinstance(user_query, str) and len(user_query.strip()) > 0,
              "User query must be a non-empty string")
     def ask_llm_simple(self, user_query: str, limit: int = 3, 
-                      model: str = "gpt-4o") -> str:
+                      model: str | KnownModelName = "openai/gpt-4o") -> str:
         """Get a simple text response from the LLM about animals.
         
         Args:
             user_query: The user's question about animals
             limit: Maximum number of search results to include
-            model: OpenAI model to use (default: gpt-4o)
+            model: Language model to use for response generation. This supports all models
+                that are supported by instructor. (See `instructor.models.KnownModelName` for
+                supported models and providers).
             
         Returns:
             Simple text response from the LLM
@@ -1141,20 +1213,32 @@ Please answer the user's question using the provided quotes and following the gu
                 limit=limit
             )
             
-            # Create OpenAI client
-            client = OpenAI()
+            # Create instructor-patched client
+            client = instructor.from_provider(
+                model = model,
+                # `instructor.from_provider` defaults to an async client
+                async_client = False
+            )
+
+            # build messages
+            # this is used to avoid instructor's overload type error
+            message : ChatCompletionMessageParam = ChatCompletionUserMessageParam(
+                content = rag_context,
+                role = "user"
+            )
+            messages : List[ChatCompletionMessageParam] = [message]
             
             # Get simple response from LLM
             response = client.chat.completions.create(
+                response_model=str,
                 model=model,
-                messages=[
-                    {"role": "user", "content": rag_context}
-                ],
-                max_tokens=500,
-                temperature=0.7
+                messages=messages,
+                max_retries=3,
             )
             
-            answer = response.choices[0].message.content
+            # response is type str already
+            answer = response
+
             logger.info(f"Simple LLM response generated for query: '{user_query[:50]}...'")
             return answer
             
@@ -1256,12 +1340,36 @@ Please answer the user's question using the provided quotes and following the gu
     @require(lambda user_query: isinstance(user_query, str) and len(user_query.strip()) > 0,
              "User query must be a non-empty string")
     @require(lambda limit: isinstance(limit, int) and limit > 0, "Limit must be a positive integer")
+    @overload
+    def rag(
+        self,
+        user_query: str,
+        limit: int = 5,
+        score_threshold: Optional[float] = None,
+        author: Optional[str] = None,
+        category: Optional[str] = None,
+        model: str = "gpt-4o",
+        response_type: Literal["structured"] = "structured",
+    ) -> RagResultStructured: ...
+
+    @overload
+    def rag(
+        self,
+        user_query: str,
+        limit: int = 5,
+        score_threshold: Optional[float] = None,
+        author: Optional[str] = None,
+        category: Optional[str] = None,
+        model: str = "gpt-4o",
+        response_type: Literal["simple"] = "simple",
+    ) -> RagResultSimple: ...
+
     def rag(self, user_query: str, limit: int = 5, 
             score_threshold: Optional[float] = None,
             author: Optional[str] = None,
             category: Optional[str] = None,
             model: str = "gpt-4o",
-            response_type: str = "structured") -> Dict[str, Any]:
+            response_type: ResponseType = "structured") -> RagResult:
         """🚀 Complete AI-powered question answering in one powerful method call.
         
         This is your one-stop solution for getting intelligent answers about animals.
@@ -1398,7 +1506,7 @@ Please answer the user's question using the provided quotes and following the gu
                 raise ValueError(f"Invalid response_type: {response_type}. Must be 'structured' or 'simple'")
             
             # Step 4: Prepare query info
-            query_info = {
+            query_info: Animals.RagQueryInfo = {
                 "user_query": user_query,
                 "limit": limit,
                 "score_threshold": score_threshold,
@@ -1410,7 +1518,7 @@ Please answer the user's question using the provided quotes and following the gu
             }
             
             # Step 5: Return complete RAG result
-            result = {
+            result: Animals.RagResult = {
                 "llm_response": llm_response,
                 "search_results": search_results,
                 "rag_context": rag_context,

--- a/src/rag_to_riches/utils/logging_config.py
+++ b/src/rag_to_riches/utils/logging_config.py
@@ -9,12 +9,12 @@
 
 from loguru import logger
 import sys
-from typing import Literal
+from typing import Literal, Optional, TypeAlias
 
-LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+LogLevel: TypeAlias = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 def configure_logging(level: LogLevel = "INFO", 
-                     format_string: str = None,
+                     format_string: Optional[str] = None,
                      colorize: bool = True) -> None:
     """
     Configure loguru logging for cleaner output in notebooks and applications.

--- a/tests/test_animals.py
+++ b/tests/test_animals.py
@@ -11,7 +11,8 @@ import pytest
 import tempfile
 import json
 from pathlib import Path
-from typing import List
+from typing import List, Generator
+import uuid
 
 from rag_to_riches.corpus.animals import Animals
 from rag_to_riches.corpus.data_models import AnimalQuote, AnimalWisdom
@@ -166,7 +167,7 @@ class TestAnimals:
     """Test suite for Animals corpus loader."""
     
     @pytest.fixture
-    def temp_jsonl_file(self) -> Path:
+    def temp_jsonl_file(self) -> Generator[Path, None, None]:
         """Create a temporary JSONL file with test data."""
         temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False)
         
@@ -180,9 +181,13 @@ class TestAnimals:
         # Cleanup
         Path(temp_file.name).unlink()
     
-    @pytest.fixture
+    @pytest.fixture(scope="session")
     def vector_db(self) -> EmbeddedVectorDB:
-        """Create a test vector database."""
+        """Create a test vector database.
+        
+        This is kept session-scoped to avoid multiple Qdrant clients
+        concurrently accessing the same embedded DB path during the test run.
+        """
         return EmbeddedVectorDB()
     
     @pytest.fixture
@@ -194,15 +199,16 @@ class TestAnimals:
     def animals_loader(self, vector_db: EmbeddedVectorDB, 
                       embedder: SimpleTextEmbedder) -> Animals:
         """Create Animals loader instance."""
+        collection_name = f"test_animals_{uuid.uuid4().hex}"
         return Animals(
             vector_db=vector_db,
             embedder=embedder,
-            collection_name="test_animals"
+            collection_name=collection_name
         )
     
     def test_animals_initialization(self, animals_loader: Animals):
         """Test Animals class initialization."""
-        assert animals_loader.collection_name == "test_animals"
+        assert animals_loader.collection_name.startswith("test_animals")
         assert animals_loader.wisdom is None
         assert isinstance(animals_loader.embedder, SimpleTextEmbedder)
         assert isinstance(animals_loader.semantic_search.vector_db, EmbeddedVectorDB)
@@ -240,7 +246,7 @@ class TestAnimals:
         """Test getting collection statistics."""
         # Test stats before loading
         stats = animals_loader.get_collection_stats()
-        assert stats["collection_name"] == "test_animals"
+        assert stats["collection_name"] == animals_loader.collection_name
         assert stats["collection_exists"] is True
         assert stats["loaded_quotes"] == 0
         
@@ -264,7 +270,7 @@ class TestAnimals:
         assert isinstance(results, list)
         assert len(results) <= 5
         # Should find the George Orwell quote about animal equality
-        assert any("equal" in result.payload.get("content", "").lower() for result in results)
+        assert any("equal" in result.payload.get("content", "").lower() for result in results) # type: ignore
     
     def test_search_with_author_filter(self, animals_loader: Animals, temp_jsonl_file: Path):
         """Test search with author filtering."""
@@ -277,7 +283,7 @@ class TestAnimals:
         assert isinstance(results, list)
         # All results should be by George Orwell
         for result in results:
-            assert result.payload.get("author", "") == "George Orwell"
+            assert result.payload.get("author", "") == "George Orwell" # type: ignore
     
     def test_search_with_category_filter(self, animals_loader: Animals, temp_jsonl_file: Path):
         """Test search with category filtering."""
@@ -290,7 +296,7 @@ class TestAnimals:
         assert isinstance(results, list)
         # All results should be in the specified category
         for result in results:
-            assert result.payload.get("category", "") == "Wisdom and Philosophy"
+            assert result.payload.get("category", "") == "Wisdom and Philosophy" # type: ignore
     
     def test_search_with_score_threshold(self, animals_loader: Animals, temp_jsonl_file: Path):
         """Test search with score threshold."""


### PR DESCRIPTION
@asif-qamar @chandar-l 

1. Changed usage of `instructor.from_openai` to `instructor.from_provider` for LLM client initialization to allow for `instructor`'s built in auto provider routing.
2. Updated type hints within `Animals` class for stronger type definition on return types for `Animals.rag()`.
3. Updated `test_animals.py` to ensure multiple Qdrant clients are not attempting to concurrently touch the same collection.
4. Verified passing of all test cases within `test_animals.py` (attached below)

----

[TEST CASE `test_animals.py`]

```bash
========================= test session starts =========================
platform darwin -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/hammad/Development/SupportVectors/rag_to_riches
configfile: pyproject.toml
plugins: anyio-4.9.0, cov-6.2.1
collected 25 items

tests/test_animals.py .........................                 [100%]

========================== warnings summary ===========================
tests/test_animals.py::TestAnimals::test_search_basic
tests/test_animals.py::TestAnimals::test_search_with_author_filter
tests/test_animals.py::TestAnimals::test_search_with_category_filter
tests/test_animals.py::TestAnimals::test_search_with_score_threshold
  /Users/hammad/Development/SupportVectors/rag_to_riches/src/rag_to_riches/vectordb/embedded_vectordb.py:417: DeprecationWarning: `search` method is deprecated and will be removed in the future. Use `query_points` instead.
    results = self.client.search(**search_params)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 25 passed, 4 warnings in 9.24s ====================
```